### PR TITLE
Run login_citywifi only when connection SSID=CityWify is started

### DIFF
--- a/Linux/10-login_citywifi
+++ b/Linux/10-login_citywifi
@@ -29,7 +29,7 @@ login_wificity() {
         # captive portal is detected
         # assuming wificity network
         # parsing magic code to generate the wificity authentication form
-        magic=$(sed -n 's/^Location.*?\([a-zA-Z0-9]\+\).*$/\1/p' <<< "$gen204_resp")
+        magic=$(sed -n 's/.*fgtauth?([a-zA-Z0-9]+).*$/\1/p' <<< "$gen204_resp")
         # generate the authentication form
         curl -so /dev/null "${authserver}/fgtauth?${magic}"
         # submit credentials with magic code to wificity server for authentication

--- a/Linux/10-login_citywifi
+++ b/Linux/10-login_citywifi
@@ -4,7 +4,7 @@
 USERNAME=""
 PASSWORD=""
 
-login_citywifi() {
+login_wificity() {
     # wificity authentication server
     authserver="http://10.254.0.254:1000"
 
@@ -43,7 +43,7 @@ status=$2
 
 # test if the connection ID is right, and do this only when the interface has been activated
 if test "$CONNECTION_ID" = "WifiCity" && test "$status" = "up"; then
-	login_citywifi $USERNAME $PASSWORD
+	login_wificity $USERNAME $PASSWORD
 	# Optionally insert here the commands to activate a vpn to hide your traffic from CityWifi
     # Eg. wg-quick up wireguard-interface
 fi

--- a/Linux/10-login_citywifi
+++ b/Linux/10-login_citywifi
@@ -29,7 +29,7 @@ login_wificity() {
         # captive portal is detected
         # assuming wificity network
         # parsing magic code to generate the wificity authentication form
-        magic=$(sed -n 's/.*fgtauth?([a-zA-Z0-9]+).*$/\1/p' <<< "$gen204_resp")
+        magic=$(sed -n 's/.*fgtauth?\([a-zA-Z0-9]\+\).*$/\1/p' <<< "$gen204_resp")
         # generate the authentication form
         curl -so /dev/null "${authserver}/fgtauth?${magic}"
         # submit credentials with magic code to wificity server for authentication

--- a/Linux/10-login_citywifi
+++ b/Linux/10-login_citywifi
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# https://wiki.archlinux.org/index.php/NetworkManager#Captive_portals
-
-# README : make sure these binaries are available on your distribution.
-# curl sed
-
 # Insert here your username and password
 USERNAME=""
 PASSWORD=""
@@ -17,7 +12,7 @@ login_citywifi() {
     # can be any http address, eg. http://neverssl.com
     # but change the "$status" != "204" with correct status code
     # ref. https://github.com/NickSto/uptest/blob/master/captive-portals.md
-    gen204="http://www.google.com/gen_204"
+    gen204="http://detectportal.firefox.com/canonical.html"
 
     # wificity username password
     username=$1
@@ -42,4 +37,13 @@ login_citywifi() {
     fi
 }
 
-login_citywifi $USERNAME $PASSWORD
+# NetworkManager passes interface and status as arguments to the dispatch scripts
+interface=$1
+status=$2
+
+# test if the connection ID is right, and do this only when the interface has been activated
+if test "$CONNECTION_ID" = "WifiCity" && test "$status" = "up"; then
+	login_citywifi $USERNAME $PASSWORD
+	# Optionally insert here the commands to activate a vpn to hide your traffic from CityWifi
+    # Eg. wg-quick up wireguard-interface
+fi

--- a/Linux/login_wifi.sh
+++ b/Linux/login_wifi.sh
@@ -34,7 +34,7 @@ login_wificity() {
         # captive portal is detected
         # assuming wificity network
         # parsing magic code to generate the wificity authentication form
-        magic=$(sed -n 's/^Location.*?\([a-zA-Z0-9]\+\).*$/\1/p' <<< "$gen204_resp")
+        magic=$(sed -n 's/.*fgtauth?([a-zA-Z0-9]+).*$/\1/p' <<< "$gen204_resp")
         # generate the authentication form
         curl -so /dev/null "${authserver}/fgtauth?${magic}"
         # submit credentials with magic code to wificity server for authentication

--- a/Linux/login_wifi.sh
+++ b/Linux/login_wifi.sh
@@ -9,7 +9,7 @@
 USERNAME=""
 PASSWORD=""
 
-login_citywifi() {
+login_wificity() {
     # wificity authentication server
     authserver="http://10.254.0.254:1000"
 
@@ -42,4 +42,4 @@ login_citywifi() {
     fi
 }
 
-login_citywifi $USERNAME $PASSWORD
+login_wificity $USERNAME $PASSWORD

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Nothing, no particular software is required.
 
 * Open the Linux folder and download `login_wifi.sh`
 * Edit the file with your own credential
-* Automate the execution of the script every time you connect to a wifi with the following
+* Automate the execution of the script every time you connect to a wifi called
+"WifiCity"
 
 NetworkManager has the ability to start services when you connect to a network and stop them when you disconnect (e.g. when using NFS, SMB and NTPd).
 
@@ -54,9 +55,8 @@ sudo systemctl start NetworkManager-dispatcher.service
 Once the service is active, scripts can be added to the `/etc/NetworkManager/dispatcher.d` directory.
 
 ```bash=
-cd /etc/NetworkManager/dispatcher.d
 #copy your script to that directory
-cp /home/<user>/<...>/login_wifi.sh ./10-login_wifi.sh
+cp ./WifiCity_captiveportal/Linux/10-login_citywifi /etc/NetworkManager/dispatcher.d/10-login_citywifi
 ```
 
 Scripts must be owned by root, otherwise the dispatcher will not execute them. For added security, set group ownership to root as well: 


### PR DESCRIPTION
I created a new script to feed directcly to NetworkManager-dispatcher that uses nm arguments, so that it doesn't run the script with other wifi networks or on connection changes.